### PR TITLE
qtbase 6.7.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,10 @@
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+
+aggregate_check: false
+
+channels:
+  - rafaelmartins-qt
+
+upload_without_merge: true

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,82 @@
+@REM Support systems with neither capable OpenGL (desktop mode) nor DirectX 11 (ANGLE mode) drivers
+@REM https://github.com/ContinuumIO/anaconda-issues/issues/9142
+if not exist "%LIBRARY_BIN%" mkdir "%LIBRARY_BIN%"
+copy opengl32sw\opengl32sw.dll %LIBRARY_BIN%\opengl32sw.dll
+if errorlevel 1 exit /b 1
+if not exist %LIBRARY_BIN%\opengl32sw.dll exit /b 1
+
+set OPENGLVER=dynamic
+
+@REM https://bugreports.qt.io/browse/QTBUG-107009
+set "PATH=%SRC_DIR%\build\lib\qt6\bin;%PATH%"
+
+cmake -S"%SRC_DIR%/%PKG_NAME%" -B"%SRC_DIR%\build" -GNinja ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
+    -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+    -DQT_UNITY_BUILD=ON ^
+    -DINSTALL_BINDIR=lib/qt6/bin ^
+    -DINSTALL_PUBLICBINDIR=bin ^
+    -DINSTALL_LIBEXECDIR=lib/qt6 ^
+    -DINSTALL_DOCDIR=share/doc/qt6 ^
+    -DINSTALL_ARCHDATADIR=lib/qt6 ^
+    -DINSTALL_DATADIR=share/qt6 ^
+    -DINSTALL_INCLUDEDIR=include/qt6 ^
+    -DINSTALL_MKSPECSDIR=lib/qt6/mkspecs ^
+    -DINSTALL_EXAMPLESDIR=share/doc/qt6/examples ^
+    -DINSTALL_DATADIR=share/qt6 ^
+    -DQT_FEATURE_openssl=ON ^
+    -DQT_FEATURE_openssl_linked=ON ^
+    -DQT_FEATURE_glib=ON ^
+    -DQT_FEATURE_gui=ON ^
+    -DQT_FEATURE_sql=ON ^
+    -DQT_FEATURE_testlib=ON ^
+    -DQT_FEATURE_xml=ON ^
+    -DQT_FEATURE_icu=ON ^
+    -DQT_FEATURE_widgets=ON ^
+    -DQT_FEATURE_sql_sqlite=ON ^
+    -DQT_FEATURE_system_sqlite=ON ^
+    -DQT_FEATURE_sql_mysql=OFF ^
+    -DQT_FEATURE_sql_psql=ON ^
+    -DQT_FEATURE_harfbuzz=OFF ^
+    -DQT_FEATURE_jpeg=ON ^
+    -DQT_FEATURE_system_jpeg=ON ^
+    -DQT_FEATURE_system_png=ON ^
+    -DQT_FEATURE_enable_new_dtags=OFF ^
+    -DINPUT_opengl=%OPENGLVER%
+if errorlevel 1 exit 1
+
+cmake --build build --target install
+if errorlevel 1 exit 1
+
+xcopy /y /s %LIBRARY_PREFIX%\lib\qt6\bin\*.dll %LIBRARY_PREFIX%\bin
+if errorlevel 1 exit 1
+
+copy %LIBRARY_PREFIX%\lib\qt6\bin\qmake.exe %LIBRARY_PREFIX%\bin\qmake6.exe
+if errorlevel 1 exit 1
+copy %LIBRARY_PREFIX%\lib\qt6\bin\qtpaths.exe %LIBRARY_PREFIX%\bin\qtpaths6.exe
+if errorlevel 1 exit 1
+copy %LIBRARY_PREFIX%\lib\qt6\bin\androiddeployqt.exe %LIBRARY_PREFIX%\bin\androiddeployqt6.exe
+if errorlevel 1 exit 1
+copy %LIBRARY_PREFIX%\lib\qt6\bin\windeployqt.exe %LIBRARY_PREFIX%\bin\windeployqt6.exe
+if errorlevel 1 exit 1
+
+echo [Paths]                                                     > %LIBRARY_BIN%\qt6.conf
+echo Prefix = %PREFIX:\=/%                                      >> %LIBRARY_BIN%\qt6.conf
+echo Documentation = %LIBRARY_PREFIX:\=/%/share/doc/qt6         >> %LIBRARY_BIN%\qt6.conf
+echo Headers = %LIBRARY_INC:\=/%/qt6                            >> %LIBRARY_BIN%\qt6.conf
+echo Libraries = %LIBRARY_LIB:\=/%                              >> %LIBRARY_BIN%\qt6.conf
+echo LibraryExecutables = %LIBRARY_LIB:\=/%/qt6                 >> %LIBRARY_BIN%\qt6.conf
+echo Binaries = %LIBRARY_LIB:\=/%/qt6/bin                       >> %LIBRARY_BIN%\qt6.conf
+echo Plugins = %LIBRARY_LIB:\=/%/qt6/plugins                    >> %LIBRARY_BIN%\qt6.conf
+echo QmlImports = %LIBRARY_LIB:\=/%/qt6/qml                     >> %LIBRARY_BIN%\qt6.conf
+echo ArchData = %LIBRARY_LIB:\=/%/qt6                           >> %LIBRARY_BIN%\qt6.conf
+echo Data = %LIBRARY_PREFIX:\=/%/share/qt6                      >> %LIBRARY_BIN%\qt6.conf
+echo Translations = %LIBRARY_PREFIX:\=/%/share/qt6/translations >> %LIBRARY_BIN%\qt6.conf
+echo Examples = %LIBRARY_PREFIX:\=/%/share/doc/qt6/examples     >> %LIBRARY_BIN%\qt6.conf
+echo Tests = %LIBRARY_PREFIX:\=/%/tests                         >> %LIBRARY_BIN%\qt6.conf
+echo HostData = %LIBRARY_PREFIX:\=/%/lib/qt6                    >> %LIBRARY_BIN%\qt6.conf
+echo HostBinaries = %LIBRARY_LIB:\=/%/qt6/bin                   >> %LIBRARY_BIN%\qt6.conf
+echo HostLibraryExecutables = %LIBRARY_LIB:\=/%/qt6             >> %LIBRARY_BIN%\qt6.conf
+echo HostLibraries = %LIBRARY_LIB:\=/%                          >> %LIBRARY_BIN%\qt6.conf
+copy "%LIBRARY_BIN%\qt6.conf" "%PREFIX%\qt6.conf"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+
+set -ex
+
+if [[ "${target_platform}" == linux-* ]]; then
+  CMAKE_ARGS="
+    ${CMAKE_ARGS}
+    -DQT_FEATURE_egl=ON
+    -DQT_FEATURE_eglfs=ON
+    -DQT_FEATURE_xcb=ON
+    -DQT_FEATURE_xcb_xlib=ON
+    -DQT_FEATURE_xkbcommon=ON
+    -DQT_FEATURE_vulkan=OFF
+    -DQT_FEATURE_wayland=OFF
+  "
+fi
+
+cmake -S"${SRC_DIR}/${PKG_NAME}" -Bbuild -GNinja ${CMAKE_ARGS} \
+  -DCMAKE_PREFIX_PATH=${PREFIX} \
+  -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+  -DCMAKE_INSTALL_RPATH=${PREFIX}/lib \
+  -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+  -DCMAKE_FIND_FRAMEWORK=LAST \
+  -DQT_UNITY_BUILD=ON \
+  -DBUILD_WITH_PCH=OFF \
+  -DINSTALL_BINDIR=lib/qt6/bin \
+  -DINSTALL_PUBLICBINDIR=bin \
+  -DINSTALL_LIBEXECDIR=lib/qt6 \
+  -DINSTALL_DOCDIR=share/doc/qt6 \
+  -DINSTALL_ARCHDATADIR=lib/qt6 \
+  -DINSTALL_DATADIR=share/qt6 \
+  -DINSTALL_INCLUDEDIR=include/qt6 \
+  -DINSTALL_MKSPECSDIR=lib/qt6/mkspecs \
+  -DINSTALL_EXAMPLESDIR=share/doc/qt6/examples \
+  -DQT_FEATURE_openssl=ON \
+  -DQT_FEATURE_openssl_linked=ON \
+  -DQT_FEATURE_zstd=ON \
+  -DQT_FEATURE_icu=ON \
+  -DQT_FEATURE_concurrent=ON \
+  -DQT_FEATURE_dbus=ON \
+  -DQT_FEATURE_dbus_linked=OFF \
+  -DQT_FEATURE_gui=ON \
+  -DQT_FEATURE_sql=ON \
+  -DQT_FEATURE_testlib=ON \
+  -DQT_FEATURE_xml=ON \
+  -DQT_FEATURE_widgets=ON \
+  -DQT_FEATURE_sql_sqlite=ON \
+  -DQT_FEATURE_system_sqlite=ON \
+  -DQT_FEATURE_sql_mysql=ON \
+  -DQT_FEATURE_sql_psql=ON \
+  -DQT_FEATURE_mtdev=OFF \
+  -DQT_FEATURE_harfbuzz=OFF \
+  -DQT_FEATURE_system_harfbuzz=OFF \
+  -DQT_FEATURE_system_freetype=ON \
+  -DQT_FEATURE_system_jpeg=ON \
+  -DQT_FEATURE_system_pcre2=ON \
+  -DQT_FEATURE_system_png=ON \
+  -DQT_FEATURE_system_sqlite=ON \
+  -DQT_FEATURE_system_zlib=ON \
+  -DQT_FEATURE_cups=ON \
+  -DQT_FEATURE_framework=OFF \
+  -DQT_FEATURE_gssapi=ON \
+  -DQT_FEATURE_enable_new_dtags=OFF
+cmake --build build --target install
+
+pushd "${PREFIX}"
+
+mkdir -p bin
+
+if [[ -f "${SRC_DIR}"/build/user_facing_tool_links.txt ]]; then
+  for links in "${SRC_DIR}"/build/user_facing_tool_links.txt; do
+    while read _line; do
+      if [[ -n "${_line}" ]]; then
+        ln -sf ${_line}
+      fi
+    done < ${links}
+  done
+fi
+
+cat << EOF > bin/qt6.conf
+[Paths]
+Prefix = ${PREFIX}
+Documentation = ${PREFIX}/share/doc/qt6
+Headers = ${PREFIX}/include/qt6
+Libraries = ${PREFIX}/lib
+LibraryExecutables = ${PREFIX}/lib/qt6
+Binaries = ${PREFIX}/lib/qt6/bin
+Plugins = ${PREFIX}/lib/qt6/plugins
+QmlImports = ${PREFIX}/lib/qt6/qml
+ArchData = ${PREFIX}/lib/qt6
+Data = ${PREFIX}/share/qt6
+Translations = ${PREFIX}/share/qt6/translations
+Examples = ${PREFIX}/share/doc/qt6/examples
+Tests = ${PREFIX}/tests
+EOF
+
+popd

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,11 @@
+MACOSX_SDK_VERSION:
+  - '11.3'                                                   # [osx]
+CONDA_BUILD_SYSROOT:
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk  # [osx]
+c_compiler:
+  - vs2019  # [win]
+cxx_compiler:
+  - vs2019  # [win]
+macos_machine:
+  - x86_64-apple-darwin20.0.0  # [osx and x86_64]
+  - arm64-apple-darwin20.0.0   # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,138 @@
+{% set name = "qtbase" %}
+{% set version = "6.7.2" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
+    sha256: c5f22a5e10fb162895ded7de0963328e7307611c688487b5d152c9ee64767599
+    folder: {{ name }}
+    patches:
+      - patches/0001-Disable-unity-build-for-permission-plugins-in-macos.patch
+      - patches/0002-avoid-using-macos-12-resource.patch
+
+  - url: https://download.qt.io/development_releases/prebuilt/llvmpipe/windows/opengl32sw-64-mesa_12_0_rc2.7z  # [win]
+    sha256: 2a0d2f92c60e0962ef5f6039d3793424c6f39e49ba27ac04a5b21ca4ae012e15                                   # [win]
+    folder: opengl32sw                                                                                         # [win]
+
+build:
+  number: 0
+  skip: True  # [ppc64le or s390x]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x.x') }}
+  ignore_run_exports:
+    - dbus    # [unix]
+  missing_dso_whitelist:
+    - '*/api-ms-win-shcore-scaling-l1-1-1.dll'     # [win]
+    - '*/api-ms-win-core-winrt-l1-1-0.dll'         # [win]
+    - '*/api-ms-win-core-winrt-string-l1-1-0.dll'  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ cdt('libdrm-devel') }}               # [linux]
+    - {{ cdt('libglvnd-glx') }}               # [linux and not x86_64]
+    - {{ cdt('libglvnd-egl') }}               # [linux and not x86_64]
+    - {{ cdt('libice-devel') }}               # [linux]
+    - {{ cdt('libsm-devel') }}                # [linux]
+    - {{ cdt('libx11-devel') }}               # [linux]
+    - {{ cdt('libxau-devel') }}               # [linux]
+    - {{ cdt('mesa-libgl-devel') }}           # [linux]
+    - {{ cdt('mesa-libgbm') }}                # [linux]
+    - {{ cdt('mesa-libegl-devel') }}          # [linux]
+    - {{ cdt('mesa-dri-drivers') }}           # [linux]
+    - {{ cdt('xcb-util-devel') }}             # [linux]
+    - {{ cdt('xcb-util-image-devel') }}       # [linux]
+    - {{ cdt('xcb-util-keysyms-devel') }}     # [linux]
+    - {{ cdt('xcb-util-renderutil-devel') }}  # [linux]
+    - {{ cdt('xcb-util-wm-devel') }}          # [linux]
+    - {{ cdt('xorg-x11-proto-devel') }}       # [linux]
+    - patch       # [unix]
+    - pkg-config  # [unix]
+    - bison       # [linux]
+    - flex        # [linux]
+    - gperf       # [linux]
+    - jom         # [win]
+    - m2-bison    # [win]
+    - m2-flex     # [win]
+    - m2-gperf    # [win]
+    - m2-patch    # [win]
+    - cmake
+    - ninja
+    - perl
+    # linked statically on windows
+    - jpeg  # [win]
+  host:
+    - fontconfig             # [linux]
+    - krb5 1.20.1            # [linux]
+    - libcups 2.4.2          # [linux]
+    - libxkbcommon 1.0.1     # [linux]
+    - libxcb 1.15            # [linux]
+    - xcb-util-cursor 0.1.4  # [linux]
+    - dbus                   # [unix]
+    - mysql 8.4.0            # [unix]
+    - freetype               # [unix]
+    - pcre2 10.42            # [unix]
+    - libglib 2.78.4         # [unix]
+    - jpeg                   # [unix]
+    - icu
+    - libpng
+    - openssl
+    - postgresql 12.15
+    - sqlite
+    - zlib
+    - zstd
+  run:
+    - libcups 2.*  # [linux]
+    - mysql 8.4.*  # [unix]
+    - openssl
+    - sqlite
+  run_constrained:
+    - qt-main >={{ version }},<7
+    - qt >={{ version }},<7
+
+test:
+  requires:
+    - {{ compiler('cxx') }}
+    - cmake
+    - ninja
+  files:
+    - run_qt_test.sh    # [unix]
+    - run_qt_test.bat   # [win]
+    - test/main.cpp
+    - test/test_qmimedatabase.cpp
+    - test/CMakeLists.txt
+  commands:
+    - ./run_qt_test.sh  # [unix]
+    - run_qt_test.bat   # [win]
+    {% for each_qt_lib in ["Core", "Gui", "Network", "OpenGL", "OpenGLWidgets", "PrintSupport", "Sql", "Test", "Widgets", "Xml"] %}
+    - test -d $PREFIX/include/qt6/Qt{{ each_qt_lib }}                           # [unix]
+    - test -f $PREFIX/lib/libQt6{{ each_qt_lib }}${SHLIB_EXT}                   # [unix]
+    - if not exist %PREFIX%\\Library\\include\\qt6\\Qt{{ each_qt_lib }} exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\Qt6{{ each_qt_lib }}.lib exit 1      # [win]
+    - if not exist %PREFIX%\\Library\\bin\\Qt6{{ each_qt_lib }}.dll exit 1      # [win]
+    {% endfor %}
+    - test -f $PREFIX/lib/qt6/plugins/platforms/libqxcb.so                 # [linux]
+    - test -f $PREFIX/lib/qt6/plugins/platforms/libqeglfs.so               # [linux]
+    - test -f $PREFIX/lib/qt6/plugins/sqldrivers/libqsqlite${SHLIB_EXT}    # [unix]
+    - test -f $PREFIX/lib/qt6/plugins/sqldrivers/libqsqlmysql${SHLIB_EXT}  # [unix]
+    - test -f $PREFIX/lib/qt6/plugins/sqldrivers/libqsqlpsql${SHLIB_EXT}   # [unix]
+    - test -f $PREFIX/lib/qt6/plugins/imageformats/libqjpeg${SHLIB_EXT}    # [unix]
+    - test ! -f $PREFIX/lib/libQt6WaylandClient${SHLIB_EXT}                # [unix]
+    - test ! -f $PREFIX/lib/libQt6WaylandCompositor${SHLIB_EXT}            # [unix]
+    - qmake6 --version
+
+about:
+  home: https://www.qt.io/
+  license: LGPL-3.0-only
+  license_file: {{ name }}/LICENSES/LGPL-3.0-only.txt
+  license_family: LGPL
+  summary: Cross-platform application and UI framework ({{ name[2:] }} libraries).
+  description: |
+    Qt helps you create connected devices, UIs & applications that run
+    anywhere on any device, on any operating system at any time ({{ name[2:] }} libraries).
+  doc_url: https://doc.qt.io/
+  dev_url: https://github.com/qt/{{ name }}

--- a/recipe/patches/0001-Disable-unity-build-for-permission-plugins-in-macos.patch
+++ b/recipe/patches/0001-Disable-unity-build-for-permission-plugins-in-macos.patch
@@ -1,0 +1,70 @@
+From 475344bfd9b92d2bc45291a3f8c8dfb3d0e88470 Mon Sep 17 00:00:00 2001
+From: Rafael Martins <rmartins@anaconda.com>
+Date: Thu, 20 Jun 2024 00:52:32 +0200
+Subject: [PATCH 1/2] Disable unity build for permission plugins in macos
+
+---
+ src/corelib/CMakeLists.txt | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/corelib/CMakeLists.txt b/src/corelib/CMakeLists.txt
+index bbe8ba8489..11f49d506d 100644
+--- a/src/corelib/CMakeLists.txt
++++ b/src/corelib/CMakeLists.txt
+@@ -1208,6 +1208,7 @@ if(QT_FEATURE_permissions AND APPLE)
+             platform/darwin/qdarwinpermissionplugin.mm
+         PLUGIN_TYPES
+             permissions
++        NO_UNITY_BUILD
+     )
+ 
+     foreach(permission Camera Microphone Bluetooth Contacts Calendar Location)
+@@ -1217,6 +1218,7 @@ if(QT_FEATURE_permissions AND APPLE)
+     # Camera
+     qt_internal_extend_target(QDarwinCameraPermissionPlugin
+         LIBRARIES ${FWAVFoundation}
++        NO_UNITY_BUILD
+     )
+     set_property(TARGET QDarwinCameraPermissionPlugin PROPERTY
+         _qt_darwin_permissison_separate_request TRUE
+@@ -1225,6 +1227,7 @@ if(QT_FEATURE_permissions AND APPLE)
+     # Microphone
+     qt_internal_extend_target(QDarwinMicrophonePermissionPlugin
+         LIBRARIES ${FWAVFoundation}
++        NO_UNITY_BUILD
+     )
+     set_property(TARGET QDarwinMicrophonePermissionPlugin PROPERTY
+         _qt_darwin_permissison_separate_request TRUE
+@@ -1233,6 +1236,7 @@ if(QT_FEATURE_permissions AND APPLE)
+     # Bluetooth
+     qt_internal_extend_target(QDarwinBluetoothPermissionPlugin
+         LIBRARIES ${FWCoreBluetooth}
++        NO_UNITY_BUILD
+     )
+     set_property(TARGET QDarwinBluetoothPermissionPlugin PROPERTY
+         _qt_info_plist_usage_descriptions "NSBluetoothAlwaysUsageDescription"
+@@ -1241,11 +1245,13 @@ if(QT_FEATURE_permissions AND APPLE)
+     # Contacts
+     qt_internal_extend_target(QDarwinContactsPermissionPlugin
+         LIBRARIES ${FWContacts}
++        NO_UNITY_BUILD
+     )
+ 
+     # Calendar
+     qt_internal_extend_target(QDarwinCalendarPermissionPlugin
+         LIBRARIES ${FWEventKit}
++        NO_UNITY_BUILD
+     )
+     set_property(TARGET QDarwinCalendarPermissionPlugin PROPERTY
+         _qt_info_plist_usage_descriptions "NSCalendarsUsageDescription"
+@@ -1254,6 +1260,7 @@ if(QT_FEATURE_permissions AND APPLE)
+     # Location
+     qt_internal_extend_target(QDarwinLocationPermissionPlugin
+         LIBRARIES ${FWCoreLocation}
++        NO_UNITY_BUILD
+     )
+     if(MACOS)
+         set_property(TARGET QDarwinLocationPermissionPlugin PROPERTY
+-- 
+2.39.2 (Apple Git-143)
+

--- a/recipe/patches/0002-avoid-using-macos-12-resource.patch
+++ b/recipe/patches/0002-avoid-using-macos-12-resource.patch
@@ -1,0 +1,29 @@
+From 4f04e865ab0e370890a3b2c3c3d5254607abd3a9 Mon Sep 17 00:00:00 2001
+From: Rafael Martins <rmartins@anaconda.com>
+Date: Fri, 28 Jun 2024 23:18:43 +0200
+Subject: [PATCH 2/2] avoid using macos 12 resource
+
+---
+ src/plugins/platforms/cocoa/qcocoaapplicationdelegate.mm | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/plugins/platforms/cocoa/qcocoaapplicationdelegate.mm b/src/plugins/platforms/cocoa/qcocoaapplicationdelegate.mm
+index eb2745f12a..82e3dc7498 100644
+--- a/src/plugins/platforms/cocoa/qcocoaapplicationdelegate.mm
++++ b/src/plugins/platforms/cocoa/qcocoaapplicationdelegate.mm
+@@ -352,10 +352,10 @@ - (void)getUrl:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescr
+ 
+ - (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)application
+ {
+-    if (@available(macOS 12, *)) {
++    /*if (@available(macOS 12, *)) {
+         if ([reflectionDelegate respondsToSelector:_cmd])
+             return [reflectionDelegate applicationSupportsSecureRestorableState:application];
+-    }
++    }*/
+ 
+     // We don't support or implement state restorations via the AppKit
+     // state restoration APIs, but if we did, we would/should support
+-- 
+2.39.2 (Apple Git-143)
+

--- a/recipe/run_qt_test.bat
+++ b/recipe/run_qt_test.bat
@@ -1,0 +1,18 @@
+@ECHO ON
+
+if not exist %LIBRARY_BIN%\qt6.conf exit 1
+if not exist %PREFIX%\qt6.conf exit 1
+
+pushd test
+
+cmake -G"NMake Makefiles" -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" .
+if errorlevel 1 exit 1
+
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+ctest -C Release --output-on-failure
+if errorlevel 1 exit 1
+
+hello.exe
+if errorlevel 1 exit 1

--- a/recipe/run_qt_test.sh
+++ b/recipe/run_qt_test.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -ex
+
+test -f ${PREFIX}/bin/qt6.conf
+
+cmake -Stest -Bbuild -GNinja
+cmake --build build --target all
+ctest --test-dir build --output-on-failure
+
+./build/hello

--- a/recipe/test/CMakeLists.txt
+++ b/recipe/test/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required (VERSION 3.0)
+
+set (CMAKE_BUILD_TYPE "Release" CACHE STRING "build type")
+
+project (qt-main-test CXX)
+
+find_package (Qt6 CONFIG REQUIRED COMPONENTS Core)
+
+add_executable (hello main.cpp)
+target_link_libraries (hello Qt6::Core)
+
+add_executable (test_qmimedatabase test_qmimedatabase.cpp)
+target_link_libraries (test_qmimedatabase Qt6::Core)
+
+enable_testing ()
+add_test (NAME test_qmimedatabase COMMAND test_qmimedatabase)

--- a/recipe/test/main.cpp
+++ b/recipe/test/main.cpp
@@ -1,0 +1,8 @@
+#include <QCoreApplication>
+#include <QDebug>
+
+int main(int argc, char *argv[]) {
+    QCoreApplication a(argc, argv);
+    qDebug() << "Hello World!";
+    return 0;
+}

--- a/recipe/test/test_qmimedatabase.cpp
+++ b/recipe/test/test_qmimedatabase.cpp
@@ -1,0 +1,6 @@
+#include <QMimeDatabase>
+
+int main() {
+    QMimeDatabase db;
+    return (db.allMimeTypes().size() > 0)? 0: 1;
+}


### PR DESCRIPTION
qtbase 6.7.2

**Destination channel:** defaults

### Links

- [PKG-5186](https://anaconda.atlassian.net/browse/PKG-5186) 
- [Upstream repository](https://github.com/qt/qtbase)
- [Upstream changelog/diff](https://github.com/qt/qtbase/compare/v5.15.2...v6.7.2) 🤷
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock/pull/4
  - https://github.com/AnacondaRecipes/tapi-feedstock/pull/3
  - https://github.com/AnacondaRecipes/cctools-and-ld64-feedstock/pull/3

### Explanation of changes:

- Major upgrade to qt 6.7.2, splitted qt-main into several recipes.


[PKG-5186]: https://anaconda.atlassian.net/browse/PKG-5186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ