### PR TITLE
Rebuild with postgresql v17

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -6,6 +6,5 @@ aggregate_check: false
 
 channels:
   - rafaelmartins-qt
-  - https://staging.continuum.io/prefect/fs/postgresql-feedstock/pr10/c21a76d
 
 upload_without_merge: true

--- a/abs.yaml
+++ b/abs.yaml
@@ -6,5 +6,6 @@ aggregate_check: false
 
 channels:
   - rafaelmartins-qt
+  - https://staging.continuum.io/prefect/fs/postgresql-feedstock/pr10/c21a76d
 
 upload_without_merge: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     folder: opengl32sw                                                                                         # [win]
 
 build:
-  number: 0
+  number: 1
   skip: True  # [ppc64le or s390x]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
@@ -81,7 +81,7 @@ requirements:
     - icu
     - libpng
     - openssl
-    - postgresql 12.15
+    - postgresql 17.0
     - sqlite
     - zlib
     - zstd
@@ -93,6 +93,7 @@ requirements:
   run_constrained:
     - qt-main >={{ version }},<7
     - qt >={{ version }},<7
+    - {{ pin_compatible('postgresql', max_pin='x.x.x') }}
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -81,19 +81,19 @@ requirements:
     - icu
     - libpng
     - openssl
-    - postgresql 17.0
+    - libpq 17.0
     - sqlite
     - zlib
     - zstd
   run:
     - libcups 2.*  # [linux]
     - mysql 8.4.*  # [unix]
+    - libpq
     - openssl
     - sqlite
   run_constrained:
     - qt-main >={{ version }},<7
     - qt >={{ version }},<7
-    - {{ pin_compatible('postgresql', max_pin='x.x.x') }}
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,8 +63,6 @@ requirements:
     - cmake
     - ninja
     - perl
-    # linked statically on windows
-    - jpeg  # [win]
   host:
     - fontconfig             # [linux]
     - krb5 1.20.1            # [linux]
@@ -77,7 +75,7 @@ requirements:
     - freetype               # [unix]
     - pcre2 10.42            # [unix]
     - libglib 2.78.4         # [unix]
-    - jpeg                   # [unix]
+    - jpeg
     - icu
     - libpng
     - openssl


### PR DESCRIPTION
qtbase 6.7.2 b1

**Destination channel:** defaults

### Links

- [PKG-6107](https://anaconda.atlassian.net/browse/PKG-6107)
- [Upstream repository](https://github.com/qt/qtbase/tree/v6.7.2)
- [Upstream changelog/diff]()
- Relevant dependency PRs:
  - AnacondaRecipes/postgresql-feedstock#10

### Explanation of Changes

- Link `jpeg` on Windows using .dll instead of static lib.
- Use `libpq` instead of `postgresql` in deps since that's what's really required


[PKG-6107]: https://anaconda.atlassian.net/browse/PKG-6107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ