### PR TITLE
Rebuild with krb5 v1.21.3

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,10 +1,9 @@
-MACOSX_SDK_VERSION:                                          # [osx]
 # The required version for Qt is actually 12, but 0002-avoid-using-macos-12-resource.patch removes this requirement
 # and brings it back to v11.
-  - '11.3'                                                   # [osx]
-CONDA_BUILD_SYSROOT:                                         # [osx]
-  - /Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk  # [osx]
-c_compiler:
-  - vs2019  # [win]
-cxx_compiler:
-  - vs2019  # [win]
+c_stdlib_version:  # [osx]
+  - 11.3           # [osx]
+CONDA_BUILD_SYSROOT:
+  - /opt/MacOSX11.3.sdk                                      # [osx and x86_64]
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk  # [osx and arm64]
+mysql:
+  - 8.4.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,8 +18,7 @@ source:
     folder: opengl32sw                                                                                         # [win]
 
 build:
-  number: 1
-  skip: True  # [ppc64le or s390x]
+  number: 2
   skip: True  # [osx and x86_64]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
@@ -32,6 +31,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - patch       # [unix]
@@ -49,10 +49,10 @@ requirements:
     - perl
   host:
     - fontconfig {{ fontconfig }}  # [linux]
-    - krb5 1.20.1                  # [linux]
+    - krb5 {{ krb5 }}              # [linux]
     - libcups 2.4.2                # [linux]
     - dbus {{ dbus }}              # [unix]
-    - mysql 8.4.0                  # [unix]
+    - mysql {{ mysql }}            # [unix]
     - freetype {{ freetype }}      # [unix]
     - pcre2 {{ pcre2 }}            # [unix]
     - libglib {{ libglib }}        # [unix]
@@ -78,12 +78,9 @@ requirements:
     - xorg-libsm {{ xorg_libsm }}                    # [linux]
     - xorg-libx11 {{ xorg_libx11 }}                  # [linux]
   run:
-    - mesalib      # [linux]
-    - libcups 2.*  # [linux]
-    - mysql 8.4.*  # [unix]
-    - libpq
-    - openssl
-    - sqlite
+    - mesalib 25         # [linux]
+    - libcups 2.*        # [linux]
+    - mysql {{ mysql }}  # [unix]
   run_constrained:
     - qt-main >={{ version }},<7
     - qt >={{ version }},<7
@@ -146,6 +143,7 @@ outputs:
         - {{ pin_subpackage(name, max_pin='x.x') }}
     requirements:
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
       host:


### PR DESCRIPTION
qtbase 6.7.3 b2

**Destination channel:** defaults

### Links

- [PKG-8641](https://anaconda.atlassian.net/browse/PKG-8641)
- [Upstream repository](https://github.com/qt/qtbase/tree/6.7.3)
- Relevant dependency PRs:
  - AnacondaRecipes/krb5-feedstock#11
  - AnacondaRecipes/cyrus-sasl-feedstock#7
  - AnacondaRecipes/postgresql-feedstock#13

### Explanation of changes:

- Rebuild against latest `krb5`

[PKG-8641]: https://anaconda.atlassian.net/browse/PKG-8641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ