### PR TITLE
qtbase 6.7.3: rebuild against libkrb5 1.21.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/096f9c8
+  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/0a7b522

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/096f9c8

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/0a7b522
+  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/baedf3b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/baedf3b

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     folder: opengl32sw                                                                                         # [win]
 
 build:
-  number: 3
+  number: 4
   skip: True  # [osx and x86_64]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
@@ -40,16 +40,16 @@ requirements:
     - flex        # [linux]
     - gperf       # [linux]
     - jom         # [win]
-    - m2-bison    # [win]
-    - m2-flex     # [win]
-    - m2-gperf    # [win]
-    - m2-patch    # [win]
+    - msys2-bison    # [win]
+    - msys2-flex     # [win]
+    - msys2-gperf    # [win]
+    - msys2-patch    # [win]
     - cmake
     - ninja
     - perl
   host:
     - fontconfig {{ fontconfig }}  # [linux]
-    - krb5 {{ krb5 }}              # [linux]
+    - libkrb5 {{ krb5 }}              # [linux]
     - libcups 2.4.2                # [linux]
     - dbus {{ dbus }}              # [unix]
     - mysql {{ mysql }}            # [unix]


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-9031](https://anaconda.atlassian.net/browse/PKG-9031) 
- [Upstream repository](https://github.com/pythongssapi/python-gssapi)
- Issues:
  - https://github.com/ContinuumIO/anaconda-issues/issues/10772
  - https://github.com/conda-forge/krb5-feedstock/issues/48 

### Explanation of changes:

- Rebuild against libkrb5 1.21.3
- Updated build number from 3 to 4
- RUse msys2 packages

### Notes:

- This rebuild addresses downstream dependency issues with krb5 1.21.3

[PKG-9031]: https://anaconda.atlassian.net/browse/PKG-9031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ