### PR TITLE
Rebuild qtbase and qtbase-devel against pcre2 10.46 

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -41,6 +41,7 @@ cmake --log-level STATUS  -S"%SRC_DIR%/%PKG_NAME%" -B"%SRC_DIR%\build" -GNinja ^
     -DQT_FEATURE_harfbuzz=ON ^
     -DQT_FEATURE_jpeg=ON ^
     -DQT_FEATURE_system_jpeg=ON ^
+    -DQT_FEATURE_system_pcre2=ON ^
     -DQT_FEATURE_system_png=ON ^
     -DQT_FEATURE_system_harfbuzz=ON ^
     -DQT_FEATURE_vulkan=ON ^

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ build:
     - '*/api-ms-win-core-winrt-string-l1-1-0.dll'  # [win]
     - '*/api-ms-win-core-winrt-error-l1-1-0.dll'   # [win]
     - '*/api-ms-win-core-winrt-error-l1-1-1.dll'   # [win]
+    - '*/pcre2-16.dll'                             # [win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ requirements:
     - libcups 2.4.2                 # [linux]
     - dbus {{ dbus }}               # [unix]
     - freetype {{ freetype }}       # [unix]
-    - pcre2 10.42                   # [unix]
+    - pcre2 {{ pcre2 }}             # [unix]
     - glib {{ glib }}
     - harfbuzz {{ harfbuzz }}
     - icu {{ icu }}
@@ -182,7 +182,7 @@ outputs:
         - {{ compiler('cxx') }}
       host:
         - {{ pin_subpackage(name, exact=True) }}
-        - pcre2 10.42  # [unix]
+        - pcre2 {{ pcre2 }}  # [unix]
         - zstd {{ zstd }}
       run:
         - {{ pin_subpackage(name, exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,6 @@ build:
     - '*/api-ms-win-core-winrt-string-l1-1-0.dll'  # [win]
     - '*/api-ms-win-core-winrt-error-l1-1-0.dll'   # [win]
     - '*/api-ms-win-core-winrt-error-l1-1-1.dll'   # [win]
-    - '*/pcre2-16.dll'                             # [win]
 
 requirements:
   build:
@@ -57,7 +56,7 @@ requirements:
     - libcups 2.4.2                 # [linux]
     - dbus {{ dbus }}               # [unix]
     - freetype {{ freetype }}       # [unix]
-    - pcre2 {{ pcre2 }}             # [unix]
+    - pcre2 {{ pcre2 }}
     - glib {{ glib }}
     - harfbuzz {{ harfbuzz }}
     - icu {{ icu }}
@@ -183,7 +182,7 @@ outputs:
         - {{ compiler('cxx') }}
       host:
         - {{ pin_subpackage(name, exact=True) }}
-        - pcre2 {{ pcre2 }}  # [unix]
+        - pcre2 {{ pcre2 }}
         - zstd {{ zstd }}
       run:
         - {{ pin_subpackage(name, exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     folder: opengl32sw                                                                                         # [win]
 
 build:
-  number: 3
+  number: 4
   # https://doc.qt.io/qt-6/qt-releases.html#binary-compatibility
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
@@ -289,7 +289,7 @@ test:
     - test -f $PREFIX/lib/qt6/plugins/imageformats/libqjpeg${SHLIB_EXT}    # [unix]
 
 about:
-  home: https://www.qt.io/
+  home: https://www.qt.io
   license: LGPL-3.0-only
   license_file: {{ name }}/LICENSES/LGPL-3.0-only.txt
   license_family: LGPL
@@ -297,7 +297,7 @@ about:
   description: |
     Qt helps you create connected devices, UIs & applications that run
     anywhere on any device, on any operating system at any time ({{ name[2:] }} libraries).
-  doc_url: https://doc.qt.io/
+  doc_url: https://doc.qt.io
   dev_url: https://github.com/qt/{{ name }}
 
 extra:


### PR DESCRIPTION
qtbase 6.9.2

**Destination channel:** Defaults

### Links

- [PKG-10080](https://anaconda.atlassian.net/browse/PKG-10080)
- [Upstream repository](https://github.com/qt/qtbase/tree/v6.9.2)

### Explanation of changes:

- Increase build number
- Change `pcre2` pinning to from cbc
- Add `pcre2` as a feature for Windows build



[PKG-10080]: https://anaconda.atlassian.net/browse/PKG-10080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ