### PR TITLE
correct prefixpath

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -68,6 +68,7 @@ if errorlevel 1 exit 1
 mkdir %LIBRARY_PREFIX%\share\qt6
 copy .\build\config.summary %LIBRARY_PREFIX%\share\qt6\config.summary
 
+:: Create qt6.conf file. See: https://doc.qt.io/qt-6/qt-conf.html
 echo [Paths]                                                     > %LIBRARY_BIN%\qt6.conf
 echo Prefix = %PREFIX:\=/%                                      >> %LIBRARY_BIN%\qt6.conf
 echo Documentation = %LIBRARY_PREFIX:\=/%/share/doc/qt6         >> %LIBRARY_BIN%\qt6.conf
@@ -87,3 +88,4 @@ echo HostBinaries = %LIBRARY_LIB:\=/%/qt6/bin                   >> %LIBRARY_BIN%
 echo HostLibraryExecutables = %LIBRARY_LIB:\=/%/qt6             >> %LIBRARY_BIN%\qt6.conf
 echo HostLibraries = %LIBRARY_LIB:\=/%                          >> %LIBRARY_BIN%\qt6.conf
 copy "%LIBRARY_BIN%\qt6.conf" "%PREFIX%\qt6.conf"
+copy "%LIBRARY_BIN%\qt6.conf" "%LIBRARY_LIB%\qt6\qt6.conf"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -88,4 +88,3 @@ echo HostBinaries = %LIBRARY_LIB:\=/%/qt6/bin                   >> %LIBRARY_BIN%
 echo HostLibraryExecutables = %LIBRARY_LIB:\=/%/qt6             >> %LIBRARY_BIN%\qt6.conf
 echo HostLibraries = %LIBRARY_LIB:\=/%                          >> %LIBRARY_BIN%\qt6.conf
 copy "%LIBRARY_BIN%\qt6.conf" "%PREFIX%\qt6.conf"
-copy "%LIBRARY_BIN%\qt6.conf" "%LIBRARY_LIB%\qt6\qt6.conf"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -123,5 +123,5 @@ Translations = ${PREFIX}/share/qt6/translations
 Examples = ${PREFIX}/share/doc/qt6/examples
 Tests = ${PREFIX}/tests
 EOF
-
+cp ${PREFIX}/bin/qt6.conf ${PREFIX}/lib/qt6/qt6.conf
 popd

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -123,5 +123,5 @@ Translations = ${PREFIX}/share/qt6/translations
 Examples = ${PREFIX}/share/doc/qt6/examples
 Tests = ${PREFIX}/tests
 EOF
-cp ${PREFIX}/bin/qt6.conf ${PREFIX}/lib/qt6/qt6.conf
+
 popd

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -18,9 +18,9 @@ cxx_compiler:  # [win]
 # XCode 15.0 came with SDK 14.0 and clang 15
 # https://en.wikipedia.org/wiki/Xcode
 c_compiler_version:    # [osx]
-  - 17                 # [osx]
+  - 20                 # [osx]
 cxx_compiler_version:  # [osx]
-  - 17                 # [osx]
+  - 20                 # [osx]
 
 # Have to leave this for now or else the overlinking checks fail when we revert back to the aggregate CBC and use the
 # 12.1 sysroot.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -169,7 +169,6 @@ outputs:
       # qt.conf files are overrides used for plugins so should go wherever the plugins go.
       - qt6.conf                           # [win]
       - {{ win_prefix }}bin/qt6.conf
-      - {{ win_prefix }}lib/qt6/qt6.conf
       - {{ win_prefix }}lib/qt6/plugins
       - {{ win_prefix }}share/doc/qt6
       - {{ win_prefix }}share/qt6/config.summary

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     folder: opengl32sw                                                                                         # [win]
 
 build:
-  number: 4
+  number: 5
   # https://doc.qt.io/qt-6/qt-releases.html#binary-compatibility
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
@@ -167,6 +167,7 @@ outputs:
       # qt.conf files are overrides used for plugins so should go wherever the plugins go.
       - qt6.conf                           # [win]
       - {{ win_prefix }}bin/qt6.conf
+      - {{ win_prefix }}lib/qt6/qt6.conf
       - {{ win_prefix }}lib/qt6/plugins
       - {{ win_prefix }}share/doc/qt6
       - {{ win_prefix }}share/qt6/config.summary

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,8 @@ source:
       # https://doc.qt.io/qt-6/macos.html
       - patches/0002-set-xcode-version.patch  # [osx]
       - patches/0003-force-qmake-to-use-sdkroot-on-osx.patch  # [osx]
+      - patches/0004-qt6-conf-osx.patch  # [osx]
+      - patches/0005-fix-qlibraryinfo-prefixpath-windows.patch # [win]
 
   - url: https://download.qt.io/development_releases/prebuilt/llvmpipe/windows/opengl32sw-64-mesa_12_0_rc2.7z  # [win]
     sha256: 2a0d2f92c60e0962ef5f6039d3793424c6f39e49ba27ac04a5b21ca4ae012e15                                   # [win]

--- a/recipe/patches/0004-qt6-conf-osx.patch
+++ b/recipe/patches/0004-qt6-conf-osx.patch
@@ -1,0 +1,27 @@
+Addresses: https://github.com/conda-forge/qt-main-feedstock/issues/150
+diff --git a/src/corelib/global/qlibraryinfo.cpp b/src/corelib/global/qlibraryinfo.cpp
+index 94f3e60deba..65b87778779 100644
+--- a/qtbase/src/corelib/global/qlibraryinfo.cpp
++++ b/qtbase/src/corelib/global/qlibraryinfo.cpp
+@@ -105,21 +105,6 @@ static std::unique_ptr<QSettings> findConfiguration()
+     QString qtconfig = QStringLiteral(":/qt/etc/qt.conf");
+     if (QFile::exists(qtconfig))
+         return std::make_unique<QSettings>(qtconfig, QSettings::IniFormat);
+-#ifdef Q_OS_DARWIN
+-    CFBundleRef bundleRef = CFBundleGetMainBundle();
+-    if (bundleRef) {
+-        QCFType<CFURLRef> urlRef = CFBundleCopyResourceURL(bundleRef,
+-                                                           QCFString("qt.conf"_L1),
+-                                                           0,
+-                                                           0);
+-        if (urlRef) {
+-            QCFString path = CFURLCopyFileSystemPath(urlRef, kCFURLPOSIXPathStyle);
+-            qtconfig = QDir::cleanPath(path);
+-            if (QFile::exists(qtconfig))
+-                return std::make_unique<QSettings>(qtconfig, QSettings::IniFormat);
+-        }
+-    }
+-#endif
+     if (QCoreApplication::instance()) {
+         QDir pwd(QCoreApplication::applicationDirPath());
+         qtconfig = pwd.filePath(u"qt" QT_STRINGIFY(QT_VERSION_MAJOR) ".conf"_s);

--- a/recipe/patches/0005-fix-qlibraryinfo-prefixpath-windows.patch
+++ b/recipe/patches/0005-fix-qlibraryinfo-prefixpath-windows.patch
@@ -1,0 +1,33 @@
+From d708dbaf74f5bcaadc4424a4c662aaa4b3369f26 Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio@traversaro.it>
+Date: Mon, 13 Oct 2025 13:33:46 +0200
+Subject: [PATCH] Handle library location path for Windows builds
+
+Add conditional path handling for Windows in QtQmakeHelpers.
+See: https://github.com/conda-forge/qt-main-feedstock/pull/365
+---
+ qtbase/cmake/QtQmakeHelpers.cmake | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/qtbase/cmake/QtQmakeHelpers.cmake b/qtbase/cmake/QtQmakeHelpers.cmake
+index c618fa051096..6d92074abd17 100644
+--- a/qtbase/cmake/QtQmakeHelpers.cmake
++++ b/qtbase/cmake/QtQmakeHelpers.cmake
+@@ -46,7 +46,15 @@ function(qt_generate_qconfig_cpp in_file out_file)
+     endif()
+     file(RELATIVE_PATH from_lib_location_to_prefix
+          "${lib_location_absolute_path}" "${QT_BUILD_INTERNALS_RELOCATABLE_INSTALL_PREFIX}")
+-    set(QT_CONFIGURE_LIBLOCATION_TO_PREFIX_PATH "${from_lib_location_to_prefix}")
++    if(WIN32)
++      # In conda-forge, the .dll are manually copied from <install_prefix>/lib/qt6/bin to
++      # <install_prefix>/bin after the CMake install, and the one actually loaded by the loader
++      # are the one in <install_prefix>/bin, so we hardcode the QT_CONFIGURE_LIBLOCATION_TO_PREFIX_PATH
++      # to be .., to avoid issues like https://github.com/conda-forge/qt-main-feedstock/issues/275
++      set(QT_CONFIGURE_LIBLOCATION_TO_PREFIX_PATH "..")
++    else()
++      set(QT_CONFIGURE_LIBLOCATION_TO_PREFIX_PATH "${from_lib_location_to_prefix}")
++    endif()
+ 
+     # Ensure Windows drive letter is prepended to the install prefix hardcoded
+     # into qconfig.cpp, otherwise qmake can't find Qt modules in a static Qt
+

--- a/recipe/test/CMakeLists.txt
+++ b/recipe/test/CMakeLists.txt
@@ -45,6 +45,9 @@ target_link_libraries (widgets_test PRIVATE Qt6::Widgets)
 add_executable (xml_test test_xml.cpp)
 target_link_libraries (xml_test PRIVATE Qt6::Xml)
 
+add_executable (test_qlibraryinfo_prefixpath test_qlibraryinfo_prefixpath.cpp)
+target_link_libraries (test_qlibraryinfo_prefixpath Qt6::Core)
+
 enable_testing ()
 add_test (NAME test_concurrent COMMAND concurrent_test)
 add_test (NAME test_core COMMAND core_test)
@@ -57,6 +60,7 @@ add_test (NAME test_sql COMMAND sql_test)
 add_test (NAME test_test COMMAND test_test)
 add_test (NAME test_widgets COMMAND widgets_test)
 add_test (NAME test_xml COMMAND xml_test)
+add_test (NAME test_qlibraryinfo_prefixpath COMMAND test_qlibraryinfo_prefixpath)
 
 if (NOT WIN32)
   add_test (NAME test_opengl COMMAND opengl_test)

--- a/recipe/test/test_qlibraryinfo_prefixpath.cpp
+++ b/recipe/test/test_qlibraryinfo_prefixpath.cpp
@@ -1,0 +1,48 @@
+#include <QCoreApplication>
+#include <QLibraryInfo>
+#include <QDebug>
+#include <cstdlib>
+#include <QDir>
+
+// This is a regression test for https://github.com/conda-forge/qt-main-feedstock/issues/275
+int main(int argc, char *argv[])
+{
+    QString prefixPath = QLibraryInfo::path(QLibraryInfo::PrefixPath);
+
+    QByteArray envCondaprefix = qgetenv("CONDA_PREFIX");
+    if (envCondaprefix.isEmpty()) {
+        qCritical() << "CONDA_PREFIX is not set in the environment";
+        return EXIT_FAILURE;
+    }
+
+    QString expected = QString::fromUtf8(envCondaprefix.constData());
+
+#ifdef Q_OS_WIN
+    // On Windows, Qt installs under %CONDA_PREFIX%/Library
+    QDir d(expected);
+    expected = QDir::cleanPath(d.filePath("Library"));
+#else
+    expected = QDir::cleanPath(expected);
+#endif
+
+    QString actual = QDir::cleanPath(prefixPath);
+
+    bool comparison = false;
+
+    // On Windows comparison should be case-insensitive
+#ifdef Q_OS_WIN
+    comparison = (actual.compare(expected, Qt::CaseInsensitive) == 0);
+#else
+    comparison = (actual == expected);
+#endif
+
+    if (!comparison) {
+        qCritical() << "Prefix mismatch:";
+        qCritical() << "  QLibraryInfo::PrefixPath:" << actual;
+        qCritical() << "  Expected:" << expected;
+        return EXIT_FAILURE;
+    }
+
+    qDebug() << "Prefix matches expected:" << actual;
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
rebuild to address qtwebengine rendering issues due to resources not found.

**Destination channel:** main

### Links

- [PKG-10731](https://anaconda.atlassian.net/browse/PKG-10731)

### Explanation of changes:

- On Windows, `QLibraryInfo.LibraryPath.PrefixPath` incorrectly points to `C:/miniconda3/envs` due to dlls being copied to <install_prefix>/bin. Adding a patch from https://github.com/conda-forge/qt-main-feedstock/pull/365 to correct this. An alternative was to copy qt6.conf to each bin directory. 
- Also adding a patch on macos to avoid issues when mixing qt5 and qt6. 


[PKG-10731]: https://anaconda.atlassian.net/browse/PKG-10731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ