### PR TITLE
Rebuild for libkrb5 1.22.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
     folder: opengl32sw                                                                                         # [win]
 
 build:
-  number: 5
+  number: 6
   # https://doc.qt.io/qt-6/qt-releases.html#binary-compatibility
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}


### PR DESCRIPTION
[PKG-11955](https://anaconda.atlassian.net/browse/PKG-11955) Rebuild for libkrb5 1.22.1

# NOTE
Keeping minimal changes to avoid merge conflicts for work done on version 6.10

[PKG-11955]: https://anaconda.atlassian.net/browse/PKG-11955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ