### PR TITLE
PKG-11817: qtbase 6.11

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -16,7 +16,6 @@ cmake --log-level STATUS  -S"%SRC_DIR%/%PKG_NAME%" -B"%SRC_DIR%\build" -GNinja ^
     -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
     -DQT_UNITY_BUILD=ON ^
     -DINSTALL_BINDIR=lib/qt6/bin ^
-    -DINSTALL_PUBLICBINDIR=bin ^
     -DINSTALL_LIBEXECDIR=lib/qt6 ^
     -DINSTALL_DOCDIR=share/doc/qt6 ^
     -DINSTALL_ARCHDATADIR=lib/qt6 ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -23,6 +23,7 @@ if [[ "${target_platform}" == linux-* ]]; then
     -DQT_FEATURE_xkbcommon=ON
     -DQT_FEATURE_vulkan=ON
     -DQT_FEATURE_wayland=ON
+    -DFEATURE_liburing=OFF
   "
 else
   # TODO: Somehow set APPLICATION_EXTENSION_API_ONLY on OSX to avoid this?

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "qtbase" %}
-{% set version = "6.10.2" %}
+{% set version = "6.11.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
-    sha256: aeb78d29291a2b5fd53cb55950f8f5065b4978c25fb1d77f627d695ab9adf21e
+    sha256: 231ad85979864d914dc9568a1b71c91d6cf20d7b2021d059103bf0eb51cb755e
     folder: {{ name }}
     patches:
       # https://doc.qt.io/qt-6/macos.html#supported-configurations

--- a/recipe/patches/0001-Set-XCode-version-15.patch
+++ b/recipe/patches/0001-Set-XCode-version-15.patch
@@ -4,14 +4,14 @@ Date: Mon, 26 Jan 2026 02:55:44 -0800
 Subject: [PATCH] Set XCode version 15
 
 ---
- cmake/QtPublicAppleHelpers.cmake | 35 ++++++++++++++++----------------
- 1 file changed, 18 insertions(+), 17 deletions(-)
+ cmake/QtPublicAppleHelpers.cmake | 23 ++++++++++++-----------
+ 1 file changed, 12 insertions(+), 11 deletions(-)
 
 diff --git a/cmake/QtPublicAppleHelpers.cmake b/cmake/QtPublicAppleHelpers.cmake
-index 3ffe53c6..ce4d9f52 100644
+index 5d90c454..f4ccba69 100644
 --- a/cmake/QtPublicAppleHelpers.cmake
 +++ b/cmake/QtPublicAppleHelpers.cmake
-@@ -929,23 +929,24 @@ function(_qt_internal_get_apple_sdk_version out_var)
+@@ -929,17 +929,18 @@ function(_qt_internal_get_apple_sdk_version out_var)
  endfunction()
  
  function(_qt_internal_get_xcode_version_raw out_var)
@@ -24,12 +24,6 @@ index 3ffe53c6..ce4d9f52 100644
 -
 -        string(REPLACE "\n" " " xcode_version "${xcode_version}")
 -        string(STRIP "${xcode_version}" xcode_version)
--
--        if(NOT xcode_version)
--            message(FATAL_ERROR
--                    "Can't determine Xcode version. Is Xcode installed?"
--                    " Error details:\n${xcrun_error}")
--        endif()
 -    endif()
 -    set(${out_var} "${xcode_version}" PARENT_SCOPE)
 +#    set(xcode_version "")
@@ -41,12 +35,6 @@ index 3ffe53c6..ce4d9f52 100644
 +#
 +#        string(REPLACE "\n" " " xcode_version "${xcode_version}")
 +#        string(STRIP "${xcode_version}" xcode_version)
-+#
-+#        if(NOT xcode_version)
-+#            message(FATAL_ERROR
-+#                    "Can't determine Xcode version. Is Xcode installed?"
-+#                    " Error details:\n${xcrun_error}")
-+#        endif()
 +#    endif()
 +#    set(${out_var} "${xcode_version}" PARENT_SCOPE)
 +    set(${out_var} "15.0" PARENT_SCOPE)


### PR DESCRIPTION
qtbase 6.11

**Destination channel:** defaults

### Links

- [PKG-11817](https://anaconda.atlassian.net/browse/PKG-11817) 
- [Upstream repository](https://github.com/qt/qtbase/tree/6.11)

### Explanation of changes:

- **INSTALL_PUBLICBINDIR** removed, binaries copied manually at the end of the script
- Disabled **uring** - don`t need optional optimization path



[PKG-11817]: https://anaconda.atlassian.net/browse/PKG-11817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ