### PR TITLE
Rebuild against libjpeg-turbo

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ source:
     folder: opengl32sw                                                                                         # [win]
 
 build:
-  number: 1
+  number: 2
   # https://doc.qt.io/qt-6/qt-releases.html#binary-compatibility
   # compiled against Qt 6.0.0 should still run with any other Qt 6 release
   run_exports:
@@ -69,7 +69,7 @@ requirements:
     - glib {{ glib }}
     - harfbuzz {{ harfbuzz }}
     - icu {{ icu }}
-    - jpeg {{ jpeg }}
+    - libjpeg-turbo {{ libjpeg_turbo }}
     - libpng {{ libpng }}
     - libpq {{ libpq }}
     - mysql-devel {{ mysql_libs }}


### PR DESCRIPTION
qtbase 6.11.0

**Destination channel:** defaults

### Links

- [PKG-13223](https://anaconda.atlassian.net/browse/PKG-13223) 
- [Upstream repository](https://github.com/qt/qtbase/tree/v6.11.0)

### Explanation of changes:
- New build number
- jpeg library is replaced on libjpeg-turbo


[PKG-13223]: https://anaconda.atlassian.net/browse/PKG-13223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ